### PR TITLE
MoneyProvider::parse doesn't correctly handle float precision

### DIFF
--- a/src/Date/DayOfTheWeekFormatter.php
+++ b/src/Date/DayOfTheWeekFormatter.php
@@ -37,7 +37,6 @@ class DayOfTheWeekFormatter
      */
     public function format(int $isoNumericDay, ?string $locale = null): string
     {
-        // @phpstan-ignore-next-line  reason: https://phpstan.org/r/756b75de-525b-4c99-85ad-a06afecdd309
         if ($isoNumericDay < self::MONDAY || $isoNumericDay > self::SUNDAY) {
             throw new InvalidArgumentException(
                 sprintf("'%d is not a valid ISO-8601 numeric representation of the day of the week.", $isoNumericDay)

--- a/src/Money/MoneyProvider.php
+++ b/src/Money/MoneyProvider.php
@@ -46,10 +46,7 @@ class MoneyProvider
             throw new MoneyParseException('Amount: ' . $amount . ' and currencyCode: ' . ($currencyCode ?? $this->currency->getCode()));
         }
 
-        // convert float to string without triggering scientific notations
-        $amount = sprintf("%.20f", $parsedAmount);
-
-        return $this->parser->parse($amount, $currencyCode !== null ? new Currency($currencyCode) : $this->currency);
+        return $this->parser->parse($this->floatToString($parsedAmount), $currencyCode !== null ? new Currency($currencyCode) : $this->currency);
     }
 
     /**
@@ -65,5 +62,20 @@ class MoneyProvider
     public function getMoney($amount, ?string $currencyCode = null): Money
     {
         return new Money($amount, $currencyCode !== null ? new Currency($currencyCode) : $this->currency);
+    }
+
+    /**
+     * Convert float to string without triggering scientific notations
+     */
+    private function floatToString(float $float): string
+    {
+        $string = (string)$float;
+
+        if (preg_match('~\.(\d+)E([+-])?(\d+)~', $string, $matches) === 1) {
+            $decimals = $matches[2] === '-' ? strlen($matches[1]) + (int)$matches[3] : 0;
+            $string   = number_format($float, $decimals, '.', '');
+        }
+
+        return $string;
     }
 }

--- a/src/Money/MoneyProvider.php
+++ b/src/Money/MoneyProvider.php
@@ -46,7 +46,10 @@ class MoneyProvider
             throw new MoneyParseException('Amount: ' . $amount . ' and currencyCode: ' . ($currencyCode ?? $this->currency->getCode()));
         }
 
-        return $this->parser->parse((string)$parsedAmount, $currencyCode !== null ? new Currency($currencyCode) : $this->currency);
+        // convert float to string without triggering scientific notations
+        $amount = sprintf("%.20f", $parsedAmount);
+
+        return $this->parser->parse($amount, $currencyCode !== null ? new Currency($currencyCode) : $this->currency);
     }
 
     /**

--- a/tests/Unit/Money/MoneyProviderTest.php
+++ b/tests/Unit/Money/MoneyProviderTest.php
@@ -162,6 +162,11 @@ class MoneyProviderTest extends TestCase
                 'expected'     => '-10',
                 'price'        => '-00.1',
                 'currencyCode' => 'EUR'
+            ],
+            [
+                'expected'     => '500',
+                'price'        => '5.00000000000005684342',
+                'currencyCode' => 'EUR'
             ]
         ];
     }

--- a/tests/Unit/Money/MoneyProviderTest.php
+++ b/tests/Unit/Money/MoneyProviderTest.php
@@ -15,6 +15,7 @@ class MoneyProviderTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::parse
+     * @covers ::floatToString
      * @dataProvider provideFloat
      * @throws MoneyParseException
      */
@@ -164,10 +165,10 @@ class MoneyProviderTest extends TestCase
                 'currencyCode' => 'EUR'
             ],
             [
-                'expected'     => '500',
-                'price'        => '5.00000000000005684342',
+                'expected'     => '0',
+                'price'        => '0.00000000000005684342',
                 'currencyCode' => 'EUR'
-            ]
+            ],
         ];
     }
 


### PR DESCRIPTION
The value `0.00000000000005684342` triggers exception in Money's DecimalMoneyParser, caused by `string` > `float` > `string` conversion in MoneyProvider