### PR TITLE
Add phonenumber formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,34 @@ $formatter->format(DayOfTheWeekFormatter::MONDAY, 'en_US');
 // output: Monday
 ```
 
+### PhoneNumberFormatService
+Format phoneNumbers
+```php
+use DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions;
+use DR\Internationalization\PhoneNumberFormatService;
+
+// set default configuration
+$phoneNumberOptions = (new PhoneNumberFormatOptions())
+    ->setDefaultCountryCode('NL')
+    ->setFormat(PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL);
+$service = new PhoneNumberFormatService($phoneNumberOptions);
+
+$service->format("+31612345678");                                                       
+// output: 0031612345678
+
+$service->format("0612345678");                                                       
+// output: 0031612345678
+```
 
 ## Project structure
 
-| Directory | Description                                                                                           |
-|-----------|-------------------------------------------------------------------------------------------------------|
-| Currency  | Format `int`, `float` or `Money` value to locale specific format. Use `NumberFormatService::currency` |
-| Date      | Format ISO-8601 day of the week to user friendly names                                                | 
-| Money     | Create `Money` object from `float`                                                                    |
-| Number    | Format `int` or `float` value to locale specific format. Use `NumberFormatService::number`            |              
+| Directory   | Description                                                                                           |
+|-------------|-------------------------------------------------------------------------------------------------------|
+| Currency    | Format `int`, `float` or `Money` value to locale specific format. Use `NumberFormatService::currency` |
+| Date        | Format ISO-8601 day of the week to user friendly names                                                | 
+| Money       | Create `Money` object from `float`                                                                    |
+| Number      | Format `int` or `float` value to locale specific format. Use `NumberFormatService::number`            |              
+| PhoneNumber | Format phoneNumber value to specified format. Use `PhoneNumberFormatService::format`                  |              
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": ">=8.0",
         "ext-intl": "*",
+        "giggsey/libphonenumber-for-php-lite": "^8.13",
         "moneyphp/money": "^3.3 || ^4.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=8.0",
         "ext-intl": "*",
-        "giggsey/libphonenumber-for-php-lite": "^8.13",
+        "giggsey/libphonenumber-for-php-lite": "^8.13.11",
         "moneyphp/money": "^3.3 || ^4.0"
     },
     "autoload": {

--- a/src/Date/DayOfTheWeekFormatter.php
+++ b/src/Date/DayOfTheWeekFormatter.php
@@ -37,7 +37,6 @@ class DayOfTheWeekFormatter
      */
     public function format(int $isoNumericDay, ?string $locale = null): string
     {
-        // @phpstan-ignore-next-line  reason: https://phpstan.org/r/756b75de-525b-4c99-85ad-a06afecdd309
         if ($isoNumericDay < self::MONDAY || $isoNumericDay > self::SUNDAY) {
             throw new InvalidArgumentException(
                 sprintf("'%d is not a valid ISO-8601 numeric representation of the day of the week.", $isoNumericDay)

--- a/src/PhoneNumber/PhoneNumberFormatOptions.php
+++ b/src/PhoneNumber/PhoneNumberFormatOptions.php
@@ -11,23 +11,42 @@ use libphonenumber\PhoneNumberFormat;
  */
 class PhoneNumberFormatOptions
 {
+    /**
+     * Formats the NL phoneNumber "101234567" as "+31101234567"
+     */
     public const FORMAT_E164 = PhoneNumberFormat::E164;
+
+    /**
+     * Formats the NL phoneNumber "101234567" as "+31 10 123 4567"
+     */
     public const FORMAT_INTERNATIONAL = PhoneNumberFormat::INTERNATIONAL;
+
+    /**
+     * Formats the NL phoneNumber "101234567" as "010 123 4567"
+     */
     public const FORMAT_NATIONAL = PhoneNumberFormat::NATIONAL;
+
+    /**
+     * Formats the NL phoneNumber "101234567" as "tel:+31-10-123-4567"
+     */
     public const FORMAT_RFC3966 = PhoneNumberFormat::RFC3966;
+
+    /**
+     * Formats the NL phoneNumber "101234567" as "0031101234567"
+     */
     public const FORMAT_INTERNATIONAL_DIAL = 4;
 
-    private ?string $defaultRegion = null;
+    private ?string $defaultCountryCode = null;
     private ?int $format = null;
 
-    public function getDefaultRegion(): ?string
+    public function getDefaultCountryCode(): ?string
     {
-        return $this->defaultRegion;
+        return $this->defaultCountryCode;
     }
 
-    public function setDefaultRegion(?string $defaultRegion): self
+    public function setDefaultCountryCode(?string $defaultCountryCode): self
     {
-        $this->defaultRegion = $defaultRegion;
+        $this->defaultCountryCode = $defaultCountryCode;
 
         return $this;
     }

--- a/src/PhoneNumber/PhoneNumberFormatOptions.php
+++ b/src/PhoneNumber/PhoneNumberFormatOptions.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+
+namespace DR\Internationalization\PhoneNumber;
+
+use libphonenumber\PhoneNumberFormat;
+
+/**
+ * @phpstan-type Format self::FORMAT_*
+ */
+class PhoneNumberFormatOptions
+{
+    public const FORMAT_E164 = PhoneNumberFormat::E164;
+    public const FORMAT_INTERNATIONAL = PhoneNumberFormat::INTERNATIONAL;
+    public const FORMAT_NATIONAL = PhoneNumberFormat::NATIONAL;
+    public const FORMAT_RFC3966 = PhoneNumberFormat::RFC3966;
+    public const FORMAT_INTERNATIONAL_DIAL = 4;
+
+    private ?string $defaultRegion = null;
+    private ?int $format = null;
+
+    public function getDefaultRegion(): ?string
+    {
+        return $this->defaultRegion;
+    }
+
+    public function setDefaultRegion(?string $defaultRegion): self
+    {
+        $this->defaultRegion = $defaultRegion;
+
+        return $this;
+    }
+
+    public function getFormat(): ?int
+    {
+        return $this->format;
+    }
+
+    /**
+     * @phpstan-param Format $format
+     */
+    public function setFormat(?int $format): self
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+}

--- a/src/PhoneNumberFormatService.php
+++ b/src/PhoneNumberFormatService.php
@@ -6,9 +6,7 @@ namespace DR\Internationalization;
 use DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions;
 use InvalidArgumentException;
 use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberUtil;
-use RuntimeException;
 
 class PhoneNumberFormatService
 {
@@ -33,7 +31,7 @@ class PhoneNumberFormatService
         try {
             $parsedNumber = $this->phoneNumberUtil->parse($phoneNumber, $countryCode);
         } catch (NumberParseException $e) {
-            throw new RuntimeException("Unable to parse phoneNumber: " . $phoneNumber, 0, $e);
+            throw new InvalidArgumentException("Unable to parse phoneNumber: " . $phoneNumber, 0, $e);
         }
 
         if ($format === PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL) {

--- a/src/PhoneNumberFormatService.php
+++ b/src/PhoneNumberFormatService.php
@@ -22,8 +22,8 @@ class PhoneNumberFormatService
 
     public function format(string $phoneNumber, PhoneNumberFormatOptions $options = null): string
     {
-        $regionCode = $options?->getDefaultRegion() ?? $this->defaultOptions->getDefaultRegion();
-        $format     = $options?->getFormat() ?? $this->defaultOptions->getFormat();
+        $countryCode = $options?->getDefaultCountryCode() ?? $this->defaultOptions->getDefaultCountryCode();
+        $format      = $options?->getFormat() ?? $this->defaultOptions->getFormat();
         if ($format === null) {
             throw new InvalidArgumentException('PhoneNumberOptions: unable to format phoneNumber without a given format');
         }
@@ -31,14 +31,13 @@ class PhoneNumberFormatService
         $this->phoneNumberUtil ??= PhoneNumberUtil::getInstance();
 
         try {
-            /** @var PhoneNumber $parsedNumber */
-            $parsedNumber = $this->phoneNumberUtil->parse($phoneNumber, $regionCode);
+            $parsedNumber = $this->phoneNumberUtil->parse($phoneNumber, $countryCode);
         } catch (NumberParseException $e) {
             throw new RuntimeException("Unable to parse phoneNumber: " . $phoneNumber, 0, $e);
         }
 
         if ($format === PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL) {
-            $metaData = $this->phoneNumberUtil->getMetadataForRegion((string)$regionCode);
+            $metaData = $this->phoneNumberUtil->getMetadataForRegion((string)$countryCode);
             $prefix   = $metaData?->getInternationalPrefix() ?? $metaData?->getPreferredInternationalPrefix();
             if (is_numeric($prefix)) {
                 return $prefix . ltrim($this->phoneNumberUtil->format($parsedNumber, PhoneNumberFormatOptions::FORMAT_E164), '+');

--- a/src/PhoneNumberFormatService.php
+++ b/src/PhoneNumberFormatService.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Internationalization;
+
+use DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions;
+use InvalidArgumentException;
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumber;
+use libphonenumber\PhoneNumberUtil;
+use RuntimeException;
+
+class PhoneNumberFormatService
+{
+    private PhoneNumberFormatOptions $defaultOptions;
+    private ?PhoneNumberUtil $phoneNumberUtil = null;
+
+    public function __construct(PhoneNumberFormatOptions $phoneNumberOptions)
+    {
+        $this->defaultOptions = $phoneNumberOptions;
+    }
+
+    public function format(string $phoneNumber, PhoneNumberFormatOptions $options = null): string
+    {
+        $regionCode = $options?->getDefaultRegion() ?? $this->defaultOptions->getDefaultRegion();
+        $format     = $options?->getFormat() ?? $this->defaultOptions->getFormat();
+        if ($format === null) {
+            throw new InvalidArgumentException('PhoneNumberOptions: unable to format phoneNumber without a given format');
+        }
+
+        $this->phoneNumberUtil ??= PhoneNumberUtil::getInstance();
+
+        try {
+            /** @var PhoneNumber $parsedNumber */
+            $parsedNumber = $this->phoneNumberUtil->parse($phoneNumber, $regionCode);
+        } catch (NumberParseException $e) {
+            throw new RuntimeException("Unable to parse phoneNumber: " . $phoneNumber, 0, $e);
+        }
+
+        if ($format === PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL) {
+            $metaData = $this->phoneNumberUtil->getMetadataForRegion((string)$regionCode);
+            $prefix   = $metaData?->getInternationalPrefix() ?? $metaData?->getPreferredInternationalPrefix();
+            if (is_numeric($prefix)) {
+                return $prefix . ltrim($this->phoneNumberUtil->format($parsedNumber, PhoneNumberFormatOptions::FORMAT_E164), '+');
+            }
+
+            return $this->phoneNumberUtil->format($parsedNumber, PhoneNumberFormatOptions::FORMAT_E164);
+        }
+
+        return $this->phoneNumberUtil->format($parsedNumber, $format);
+    }
+}

--- a/tests/Unit/PhoneNumber/PhoneNumberFormatOptionsTest.php
+++ b/tests/Unit/PhoneNumber/PhoneNumberFormatOptionsTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Internationalization\Tests\Unit\PhoneNumber;
+
+use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
+use DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions
+ */
+class PhoneNumberFormatOptionsTest extends TestCase
+{
+    use AccessorPairAsserter;
+
+    /**
+     * @covers ::getDefaultRegion
+     * @covers ::setDefaultRegion
+     * @covers ::getFormat
+     * @covers ::setFormat
+     */
+    public function testAccessors(): void
+    {
+        $config = new ConstraintConfig();
+        $config->setAssertPropertyDefaults(true);
+        $config->setAssertConstructor(true);
+        $config->setAssertAccessorPair(true);
+        static::assertAccessorPairs(PhoneNumberFormatOptions::class, $config);
+    }
+}

--- a/tests/Unit/PhoneNumber/PhoneNumberFormatOptionsTest.php
+++ b/tests/Unit/PhoneNumber/PhoneNumberFormatOptionsTest.php
@@ -16,8 +16,8 @@ class PhoneNumberFormatOptionsTest extends TestCase
     use AccessorPairAsserter;
 
     /**
-     * @covers ::getDefaultRegion
-     * @covers ::setDefaultRegion
+     * @covers ::getDefaultCountryCode
+     * @covers ::setDefaultCountryCode
      * @covers ::getFormat
      * @covers ::setFormat
      */

--- a/tests/Unit/PhoneNumberFormatServiceTest.php
+++ b/tests/Unit/PhoneNumberFormatServiceTest.php
@@ -8,7 +8,6 @@ use DR\Internationalization\PhoneNumberFormatService;
 use Generator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 /**
  * @coversDefaultClass \DR\Internationalization\PhoneNumberFormatService
@@ -36,7 +35,7 @@ class PhoneNumberFormatServiceTest extends TestCase
         $options   = (new PhoneNumberFormatOptions())->setDefaultCountryCode("__")->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
         $formatter = new PhoneNumberFormatService($options);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Unable to parse phoneNumber: xxx");
         $formatter->format('xxx');
     }

--- a/tests/Unit/PhoneNumberFormatServiceTest.php
+++ b/tests/Unit/PhoneNumberFormatServiceTest.php
@@ -21,7 +21,7 @@ class PhoneNumberFormatServiceTest extends TestCase
      */
     public function testFormatMissingOption(): void
     {
-        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultRegion("NL"));
+        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultCountryCode("NL"));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('PhoneNumberOptions: unable to format phoneNumber without a given format');
@@ -33,7 +33,7 @@ class PhoneNumberFormatServiceTest extends TestCase
      */
     public function testFormatInvalidInput(): void
     {
-        $options   = (new PhoneNumberFormatOptions())->setDefaultRegion("__")->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $options   = (new PhoneNumberFormatOptions())->setDefaultCountryCode("__")->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
         $formatter = new PhoneNumberFormatService($options);
 
         $this->expectException(RuntimeException::class);
@@ -47,7 +47,7 @@ class PhoneNumberFormatServiceTest extends TestCase
      */
     public function testFormat(int $format, string $phoneNumber, string $expectedValue): void
     {
-        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultRegion("NL")->setFormat($format));
+        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultCountryCode("NL")->setFormat($format));
         static::assertSame($expectedValue, $formatter->format($phoneNumber));
     }
 
@@ -55,10 +55,10 @@ class PhoneNumberFormatServiceTest extends TestCase
      * @dataProvider internationalDialProvider
      * @covers ::format
      */
-    public function testFormatInternationDial(string $region, string $phoneNumber, string $expectedValue): void
+    public function testFormatInternationDial(string $countryCode, string $phoneNumber, string $expectedValue): void
     {
         $options = (new PhoneNumberFormatOptions())
-            ->setDefaultRegion($region)
+            ->setDefaultCountryCode($countryCode)
             ->setFormat(PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL);
 
         $formatter = new PhoneNumberFormatService($options);
@@ -70,7 +70,7 @@ class PhoneNumberFormatServiceTest extends TestCase
      */
     public function testFormatDefaultFormat(): void
     {
-        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultRegion('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultCountryCode('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
         $formatter = new PhoneNumberFormatService($defaultOptions);
 
         static::assertSame('010 123 4567', $formatter->format("101234567"));
@@ -80,10 +80,10 @@ class PhoneNumberFormatServiceTest extends TestCase
     /**
      * @covers ::format
      */
-    public function testFormatOverwrittenRegion(): void
+    public function testFormatOverwrittenCountryCode(): void
     {
-        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultRegion('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
-        $formatOptions  = (new PhoneNumberFormatOptions())->setDefaultRegion('GB');
+        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultCountryCode('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $formatOptions  = (new PhoneNumberFormatOptions())->setDefaultCountryCode('GB');
         $formatter      = new PhoneNumberFormatService($defaultOptions);
 
         static::assertSame('0121 234 5678', $formatter->format("1212345678", $formatOptions));

--- a/tests/Unit/PhoneNumberFormatServiceTest.php
+++ b/tests/Unit/PhoneNumberFormatServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Internationalization\Tests\Unit;
+
+use DR\Internationalization\PhoneNumber\PhoneNumberFormatOptions;
+use DR\Internationalization\PhoneNumberFormatService;
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @coversDefaultClass \DR\Internationalization\PhoneNumberFormatService
+ * @covers ::__construct
+ */
+class PhoneNumberFormatServiceTest extends TestCase
+{
+    /**
+     * @covers ::format
+     */
+    public function testFormatMissingOption(): void
+    {
+        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultRegion("NL"));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('PhoneNumberOptions: unable to format phoneNumber without a given format');
+        $formatter->format('0612345678');
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testFormatInvalidInput(): void
+    {
+        $options   = (new PhoneNumberFormatOptions())->setDefaultRegion("__")->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $formatter = new PhoneNumberFormatService($options);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unable to parse phoneNumber: xxx");
+        $formatter->format('xxx');
+    }
+
+    /**
+     * @dataProvider optionFormatProvider
+     * @covers ::format
+     */
+    public function testFormat(int $format, string $phoneNumber, string $expectedValue): void
+    {
+        $formatter = new PhoneNumberFormatService((new PhoneNumberFormatOptions())->setDefaultRegion("NL")->setFormat($format));
+        static::assertSame($expectedValue, $formatter->format($phoneNumber));
+    }
+
+    /**
+     * @dataProvider internationalDialProvider
+     * @covers ::format
+     */
+    public function testFormatInternationDial(string $region, string $phoneNumber, string $expectedValue): void
+    {
+        $options = (new PhoneNumberFormatOptions())
+            ->setDefaultRegion($region)
+            ->setFormat(PhoneNumberFormatOptions::FORMAT_INTERNATIONAL_DIAL);
+
+        $formatter = new PhoneNumberFormatService($options);
+        static::assertSame($expectedValue, $formatter->format($phoneNumber));
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testFormatDefaultFormat(): void
+    {
+        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultRegion('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $formatter = new PhoneNumberFormatService($defaultOptions);
+
+        static::assertSame('010 123 4567', $formatter->format("101234567"));
+        static::assertSame('06 12345678', $formatter->format("0612345678"));
+    }
+
+    /**
+     * @covers ::format
+     */
+    public function testFormatOverwrittenRegion(): void
+    {
+        $defaultOptions = (new PhoneNumberFormatOptions())->setDefaultRegion('NL')->setFormat(PhoneNumberFormatOptions::FORMAT_NATIONAL);
+        $formatOptions  = (new PhoneNumberFormatOptions())->setDefaultRegion('GB');
+        $formatter      = new PhoneNumberFormatService($defaultOptions);
+
+        static::assertSame('0121 234 5678', $formatter->format("1212345678", $formatOptions));
+        static::assertSame('07400 123456', $formatter->format("7400123456", $formatOptions));
+    }
+
+    public function optionFormatProvider(): Generator
+    {
+        yield [PhoneNumberFormatOptions::FORMAT_E164, "101234567", "+31101234567"];
+        yield [PhoneNumberFormatOptions::FORMAT_E164, "0612345678", "+31612345678"];
+
+        yield [PhoneNumberFormatOptions::FORMAT_INTERNATIONAL, "101234567", "+31 10 123 4567"];
+        yield [PhoneNumberFormatOptions::FORMAT_INTERNATIONAL, "0612345678", "+31 6 12345678"];
+
+        yield [PhoneNumberFormatOptions::FORMAT_NATIONAL, "101234567", "010 123 4567"];
+        yield [PhoneNumberFormatOptions::FORMAT_NATIONAL, "0612345678", "06 12345678"];
+
+        yield [PhoneNumberFormatOptions::FORMAT_RFC3966, "101234567", "tel:+31-10-123-4567"];
+        yield [PhoneNumberFormatOptions::FORMAT_RFC3966, "0612345678", "tel:+31-6-12345678"];
+    }
+
+    public function internationalDialProvider(): Generator
+    {
+        yield ['NL', '612345678', '0031612345678'];
+        yield ['NL', '0612345678', '0031612345678'];
+        yield ['NL', '+31612345678', '0031612345678'];
+        yield ['NL', '0031612345678', '0031612345678'];
+
+        yield ['BE', '412345678', '0032412345678'];
+        yield ['BE', '+32412345678', '0032412345678'];
+        yield ['BE', '0032412345678', '0032412345678'];
+
+        yield ['US', '+31612345678', '01131612345678'];
+        yield ['US', '+32412345678', '01132412345678'];
+        yield ['US', '5062345678', '01115062345678'];
+        yield ['US', '+15062345678', '01115062345678'];
+
+        // BR internationalPrefix is'00(?:1[245]|2[1-35]|31|4[13]|[56]5|99)', and has no preferredInternationalPrefix
+        yield ['BR', '+1 201-555-0123', '+12015550123'];
+    }
+}


### PR DESCRIPTION
Add phonenumber formatting, as wrapper around the giggsey/libphonenumber-for-php-lite package
This allows us to add extra formats and settings, for example the international_dial format.
- Note; unlike formatOutOfCountryCallingNumber, the international_dial format is still in the international format for own region.